### PR TITLE
fix: reduce project card subtitle opacity 🚸 

### DIFF
--- a/src/scss/portfolio.scss
+++ b/src/scss/portfolio.scss
@@ -99,7 +99,7 @@
             flex-direction: column;
             justify-content: space-between;
             padding: 0.2rem 2.5rem 0.5rem;
-            background-color: rgba(255, 255, 255, 0.15);
+            background-color: rgba(255, 255, 255, 0.25);
             color: $white-color;
             bottom: 0px;
             transition: all 0.3s;


### PR DESCRIPTION
since the project card subtitle has a glass effect background, reducing the opacity of the background-color will make the text on it more readable.

Side Note:
this change should actually be on another branch `accessibility-fixes`. I'll create that branch now.